### PR TITLE
Add require json to prevent NameError when using the client

### DIFF
--- a/lib/usda_ndb.rb
+++ b/lib/usda_ndb.rb
@@ -3,6 +3,7 @@ require 'usda_ndb/version'
 require 'usda_ndb/configurable'
 require 'usda_ndb/configuration'
 require 'rest-client'
+require 'json'
 
 module UsdaNdb
   extend UsdaNdb::Configurable

--- a/lib/usda_ndb/version.rb
+++ b/lib/usda_ndb/version.rb
@@ -1,3 +1,3 @@
 module UsdaNdb
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end


### PR DESCRIPTION
I found a small bug when hooking this gem into one of my projects, the `Client` class can't find `JSON` when trying to run the gem as-is.  See my IRB session below (only modification to the output is my API key):

```
2.3.0 :001 > require 'usda_ndb'
 => true
2.3.0 :002 > UsdaNdb::VERSION
 => "0.0.1"
2.3.0 :003 > UsdaNdb.configure do |c|
2.3.0 :004 >     c.api_key = 'KEY'
2.3.0 :005?>   end
 => "KEY"
2.3.0 :006 > UsdaNdb.search('cheese')
NameError: uninitialized constant UsdaNdb::Client::JSON
	from /Users/swh_personal/.rvm/gems/ruby-2.3.0/gems/usda_ndb-0.0.1/lib/usda_ndb/client.rb:11:in `fetch'
	from /Users/swh_personal/.rvm/gems/ruby-2.3.0/gems/usda_ndb-0.0.1/lib/usda_ndb.rb:15:in `search'
	from (irb):6
	from /Users/swh_personal/.rvm/rubies/ruby-2.3.0/bin/irb:11:in `<main>'
2.3.0 :007 > UsdaNdb.reports('01208')
NameError: uninitialized constant UsdaNdb::Client::JSON
	from /Users/swh_personal/.rvm/gems/ruby-2.3.0/gems/usda_ndb-0.0.1/lib/usda_ndb/client.rb:11:in `fetch'
	from /Users/swh_personal/.rvm/gems/ruby-2.3.0/gems/usda_ndb-0.0.1/lib/usda_ndb.rb:11:in `reports'
	from (irb):7
	from /Users/swh_personal/.rvm/rubies/ruby-2.3.0/bin/irb:11:in `<main>'
2.3.0 :008 > exit
```

I version-bumped and built the gem locally, and it worked just fine. I'm guessing that `JSON` is being used by test dependency because it doesn't seem to be getting caught in the specs. 
